### PR TITLE
Remove contribution support email from Terms page

### DIFF
--- a/kuma/javascript/src/payments/pages/terms.jsx
+++ b/kuma/javascript/src/payments/pages/terms.jsx
@@ -2,14 +2,8 @@
 import * as React from 'react';
 import SubHeader from '../components/subheaders/index.jsx';
 
-type Props = {
-    data: {
-        contributionSupportEmail: string,
-    },
-};
-
 export const title = 'Payment Terms';
-const TermsPage = ({ data: { contributionSupportEmail } }: Props) => (
+const TermsPage = () => (
     <>
         <SubHeader title={title} />
         <main
@@ -36,8 +30,8 @@ const TermsPage = ({ data: { contributionSupportEmail } }: Props) => (
 
                 <h2>Payment Authorization</h2>
                 <p>
-                    You can support MDN with monthly payments. Your payments are not
-                    tax deductible.
+                    You can support MDN with monthly payments. Your payments are
+                    not tax deductible.
                 </p>
                 <p>
                     In order to sign up for monthly payments, you must sign in
@@ -77,13 +71,13 @@ const TermsPage = ({ data: { contributionSupportEmail } }: Props) => (
                 </p>
                 <p>
                     When you choose to support MDN, you authorize us to charge
-                    the payment card you provide for the amount you choose,
-                    as a recurring monthly payment until you cancel.
+                    the payment card you provide for the amount you choose, as a
+                    recurring monthly payment until you cancel.
                 </p>
                 <h2>Cancellation</h2>
                 <p>
                     If you sign up for monthly payments, you may cancel at any
-                    time from your account settings. If you choose to cancel, we 
+                    time from your account settings. If you choose to cancel, we
                     will not charge your payment card for subsequent months.
                 </p>
                 <h2>Privacy Notice</h2>
@@ -100,11 +94,12 @@ const TermsPage = ({ data: { contributionSupportEmail } }: Props) => (
                 </p>
                 <p>
                     Mozilla receives a record of your payment, information about
-                    how much you’ve decided to pay. Mozilla does not receive your 
-                    payment details. If you sign up for an MDN account, Mozilla also
-                    receives the information you include in your account, as
-                    well as your email address and profile information from your GitHub or Google login. When
-                    Mozilla receives information from you, our{' '}
+                    how much you’ve decided to pay. Mozilla does not receive
+                    your payment details. If you sign up for an MDN account,
+                    Mozilla also receives the information you include in your
+                    account, as well as your email address and profile
+                    information from your GitHub or Google login. When Mozilla
+                    receives information from you, our{' '}
                     <a
                         href="https://www.mozilla.org/en-US/privacy/websites/"
                         target="_blank"

--- a/kuma/javascript/src/payments/pages/terms.test.jsx
+++ b/kuma/javascript/src/payments/pages/terms.test.jsx
@@ -4,17 +4,10 @@ import TermsPage, { title } from './terms.jsx';
 
 describe('Payments Terms page', () => {
     it('renders', () => {
-        const mockEmail = 'mock-support@mozilla.com';
-
-        const { queryByText, getByTestId } = render(
-            <TermsPage data={{ contributionSupportEmail: mockEmail }} />
-        );
+        const { queryByText, getByTestId } = render(<TermsPage />);
 
         // Subheader
         expect(getByTestId('subheader')).toHaveTextContent(title);
-
-        // Email
-        expect(queryByText(mockEmail)).toBeInTheDocument();
 
         // Section headers
         expect(queryByText(/^Payment Authorization$/)).toBeInTheDocument();

--- a/kuma/javascript/src/payments/routes.jsx
+++ b/kuma/javascript/src/payments/routes.jsx
@@ -22,7 +22,7 @@ export function PaymentPage(props: PageProps) {
             case slug.includes(PAYMENT_PATHS.MANAGEMENT):
                 return <ManagementPage locale={locale} />;
             case slug.includes(PAYMENT_PATHS.TERMS):
-                return <TermsPage data={data} />;
+                return <TermsPage />;
             case slug.includes(PAYMENT_PATHS.THANK_YOU):
                 return <ThankYouPage locale={locale} />;
             default:

--- a/kuma/payments/jinja2/payments/terms.html
+++ b/kuma/payments/jinja2/payments/terms.html
@@ -14,9 +14,7 @@
 {% endblock %}
 
 {% block document_head %}
-    {{ render_react("SPA", request.LANGUAGE_CODE, request.get_full_path(), {
-        "contributionSupportEmail": settings.CONTRIBUTION_SUPPORT_EMAIL,
-     })|safe }}
+    {{ render_react("SPA", request.LANGUAGE_CODE, request.get_full_path(), True)|safe }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Hi Michael,

I was reviewing your PR (https://github.com/mdn/kuma/pull/7161) and the build is failing because there are some additional changes needed in order to pass. There's an unused variable `contributionSupportEmail` being passed to the page that is no longer needed. I went ahead and made a PR against your branch with those changes, so the build should pass after this is merged with yours! 

Mindy 
